### PR TITLE
Add tests for arrayTransformations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -8,11 +8,23 @@ This tools uses the [Ramda](https://ramdajs.com/) library.
 License is GPL3
 
 ## Installation:
+
 ```
 npm i array-toolkit
 ```
+
 [Link to page on npm](https://www.npmjs.com/package/array-toolkit)
+
 ## Usage:
+
 ```
 const A = require('array-toolkit')
+```
+
+## Development
+
+### Test
+
+```
+npm run test
 ```

--- a/arrayTransformations.js
+++ b/arrayTransformations.js
@@ -6,8 +6,9 @@
 // -- license: GPL 3.0
 // --------------------------------------------------------------------------
 
+const R = require('ramda');
 //requiring it locally:
-//let dataToArray = require('./dataToArray.js')
+const buildArray = require('./dataToArray.js').buildArray;
 
 //Takes the length the array should be changed into as argument. If array longer, will shorten array. If array shorter will loop the array until desiredLength:
 //Generated with Chatgpt:
@@ -39,10 +40,7 @@ function safeSplice(inputArray, amountToRemove, indexToRemove, replaceWith) {
     if (replaceWith != undefined) {
         array1.push(replaceWith);
     }
-    let array2 = inputArray.slice(
-        indexToRemove + amountToRemove,
-        inputArray.length
-    );
+    let array2 = inputArray.slice(indexToRemove + amountToRemove, inputArray.length);
     return array1.concat(array2);
 }
 
@@ -51,11 +49,7 @@ function removeItem(arr, item) {
 }
 
 function removeMultipleItems(arr, itemsToRemove) {
-    let sortedArray = arr;
-    itemsToRemove.forEach((x) => {
-        sortedArray = this.removeItem(sortedArray, x);
-    });
-    return sortedArray;
+    return arr.filter((x) => !itemsToRemove.includes(x));
 }
 
 function scaleToRange(inputArray, inputMin, inputMax, outputMin, outputMax) {
@@ -64,8 +58,13 @@ function scaleToRange(inputArray, inputMin, inputMax, outputMin, outputMax) {
     return inputArray.map((x) => (x - inputMin) * scale + outputMin);
 }
 
+function sum(array) {
+    return array.reduce((x, acc) => x + acc, 0);
+}
+
 function scaleToSum(span, vals) {
-    return vals.map((x) => (x * span) / sum(vals));
+    const inputSum = sum(vals);
+    return vals.map((x) => (x * span) / inputSum);
 }
 
 function pick(inputArray) {
@@ -73,7 +72,7 @@ function pick(inputArray) {
 }
 
 function pickN(n, inputArray) {
-    return this.buildArray(n, (i) => pick(inputArray));
+    return buildArray(n, (i) => pick(inputArray));
 }
 
 function low2HighSort(inputArray) {
@@ -85,22 +84,20 @@ function high2LowSort(inputArray) {
 }
 
 function takeN(inputArray, n) {
-    return Array.from(
-        { length: n },
-        (_, index) => inputArray[index % inputArray.length]
-    );
+    return Array.from({ length: n }, (_, index) => inputArray[index % inputArray.length]);
 }
 
 function takeTo(targetLength, inputArray) {
-    let output = [];
+    const output = [];
     let counter = 0;
-    while (this.sum(output) < targetLength) {
-        let nextVal = inputArray[counter % inputArray.length];
+    let outputSum = 0;
+    while (outputSum < targetLength) {
+        const nextVal = inputArray[counter % inputArray.length];
         output.push(nextVal);
+        outputSum += nextVal;
         counter++;
     }
-    if (sum(output) > targetLength) {
-        outputSum = this.sum(output);
+    if (outputSum > targetLength) {
         let difference = outputSum - targetLength;
         output[output.length - 1] = output[output.length - 1] - difference;
     }
@@ -108,10 +105,10 @@ function takeTo(targetLength, inputArray) {
 }
 
 function loopTo(targetLength, inputArray) {
-    let inputSum = this.sum(inputArray);
-    let loopN = Math.ceil(targetLength / inputSum);
-    let pre = R.flatten(buildArray(loopN, (x) => inputArray));
-    return this.takeTo(targetLength, pre);
+    const inputSum = sum(inputArray);
+    const loopN = Math.ceil(targetLength / inputSum);
+    const pre = R.flatten(buildArray(loopN, (x) => inputArray));
+    return takeTo(targetLength, pre);
 }
 
 //Non ramda version:
@@ -139,10 +136,7 @@ function shuffle(array) {
     return array.reduceRight(
         (acc, _, currentIndex) => {
             const randomIndex = Math.floor(Math.random() * (currentIndex + 1));
-            [acc[currentIndex], acc[randomIndex]] = [
-                acc[randomIndex],
-                acc[currentIndex],
-            ];
+            [acc[currentIndex], acc[randomIndex]] = [acc[randomIndex], acc[currentIndex]];
             return acc;
         },
         [...array]
@@ -176,4 +170,6 @@ module.exports = {
     buildZip,
     shuffle,
     gatherBySubstring,
+    flipBooleans,
+    sum,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "array-toolkit",
+  "version": "1.2.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "array-toolkit",
+      "version": "1.2.2",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "ramda": "^0.28.0"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/ramda": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
   "version": "1.2.2",
   "main": "array-toolkit.js",
   "files": [
-      "array-toolkit.js",
-      "arrayTransformations.js",
-      "dataToArray.js",
-      "infoFromArray.js"
+    "array-toolkit.js",
+    "arrayTransformations.js",
+    "dataToArray.js",
+    "infoFromArray.js"
   ],
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/test/arrayTransformations.mjs
+++ b/test/arrayTransformations.mjs
@@ -1,0 +1,596 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+import {
+    adjustArrayLength,
+    resizeArray,
+    safeSplice,
+    removeItem,
+    removeMultipleItems,
+    scaleToRange,
+    scaleToSum,
+    pick,
+    pickN,
+    low2HighSort,
+    high2LowSort,
+    takeN,
+    takeTo,
+    loopTo,
+    zip,
+    buildZip,
+    shuffle,
+    gatherBySubstring,
+    flipBooleans,
+} from '../arrayTransformations.js';
+
+test('adjustArrayLength', async (t) => {
+    await t.test('same length', () => {
+        const result = adjustArrayLength(3, [1, 2, 3]);
+        assert.equal(result.length, 3);
+        assert.deepStrictEqual(result, [1, 2, 3]);
+    });
+
+    await t.test('smaller length', () => {
+        const result = adjustArrayLength(3, [1, 2]);
+        assert.equal(result.length, 3);
+        assert.deepStrictEqual(result, [1, 2, 1]);
+    });
+
+    await t.test('larger length', () => {
+        const result = adjustArrayLength(3, [1, 2, 3, 4]);
+        assert.equal(result.length, 3);
+        assert.deepStrictEqual(result, [1, 2, 3]);
+    });
+
+    // TODO: Error type shold be considered.
+    await t.test('array is empty (TODO: Error type shold be considered)', () => {
+        assert.throws(() => adjustArrayLength(3, []), {
+            name: 'RangeError',
+            message: 'Invalid array length',
+        });
+    });
+
+    // TODO: Error type shold be considered.
+    await t.test('array is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => adjustArrayLength(3, null), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'length')",
+        });
+    });
+});
+
+// Note: It looks that the result of `resizeArray` is same as `adjustArrayLength`.
+test('resizeArray', async (t) => {
+    await t.test('same size', () => {
+        const result = resizeArray(3, [1, 2, 3]);
+        assert.equal(result.length, 3);
+        assert.deepStrictEqual(result, [1, 2, 3]);
+    });
+
+    await t.test('smaller size', () => {
+        const result = resizeArray(3, [1, 2]);
+        assert.equal(result.length, 3);
+        assert.deepStrictEqual(result, [1, 2, 1]);
+    });
+
+    await t.test('larger size', () => {
+        const result = resizeArray(3, [1, 2, 3, 4]);
+        assert.equal(result.length, 3);
+        assert.deepStrictEqual(result, [1, 2, 3]);
+    });
+
+    // TODO: Error type shold be considered.
+    await t.test('array is empty (TODO: Error type shold be considered)', () => {
+        assert.throws(() => resizeArray(3, []), {
+            name: 'RangeError',
+            message: 'Invalid array length',
+        });
+    });
+
+    // TODO: Error type shold be considered.
+    await t.test('array is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => resizeArray(3, null), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'length')",
+        });
+    });
+});
+
+test('safeSplice', async (t) => {
+    await t.test('splice without replaceWith', () => {
+        const result = safeSplice([1, 2, 3, 4, 5, 6, 7], 2, 3);
+        assert.deepStrictEqual(result, [1, 2, 3, 6, 7]);
+    });
+
+    await t.test('splice with replaceWith', () => {
+        const result = safeSplice([1, 2, 3, 4, 5, 6, 7], 2, 3, 99);
+        assert.deepStrictEqual(result, [1, 2, 3, 99, 6, 7]);
+    });
+
+    await t.test('splice with replaceWith array', () => {
+        const result = safeSplice([1, 2, 3, 4, 5, 6, 7], 2, 3, [100, 200, 300]);
+        assert.deepStrictEqual(result, [1, 2, 3, [100, 200, 300], 6, 7]);
+    });
+
+    await t.test('amount is larger than array length', () => {
+        const result = safeSplice([1, 2, 3, 4, 5, 6, 7], 20, 3);
+        assert.deepStrictEqual(result, [1, 2, 3]);
+    });
+
+    await t.test('index is larger than array length', () => {
+        const result = safeSplice([1, 2, 3, 4, 5, 6, 7], 2, 9);
+        assert.deepStrictEqual(result, [1, 2, 3, 4, 5, 6, 7]);
+    });
+
+    await t.test('array is empty without replaceWith', () => {
+        const result = safeSplice([], 2, 3);
+        assert.deepStrictEqual(result, []);
+    });
+
+    await t.test('array is empty with replaceWith', () => {
+        const result = safeSplice([], 2, 3, 100);
+        assert.deepStrictEqual(result, [100]);
+    });
+
+    // TODO: Error type shold be considered.
+    await t.test('array is null without replaceWith (TODO: Error type shold be considered)', () => {
+        assert.throws(() => safeSplice(null, 2, 3), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'slice')",
+        });
+    });
+
+    // TODO: Error type shold be considered.
+    await t.test('array is null with replaceWith (TODO: Error type shold be considered)', () => {
+        assert.throws(() => safeSplice(null, 2, 3, 99), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'slice')",
+        });
+    });
+});
+
+test('removeItem', async (t) => {
+    await t.test('remove item', () => {
+        const result = removeItem([1, 2, 3], 2);
+        assert.deepStrictEqual(result, [1, 3]);
+    });
+
+    await t.test('remove multiple items', () => {
+        const result = removeItem([1, 2, 3, 4, 2, 5, 2, 6, 2], 2);
+        assert.deepStrictEqual(result, [1, 3, 4, 5, 6]);
+    });
+
+    await t.test('remove nothing', () => {
+        const result = removeItem([1, 2, 3, 4, 5, 6], 7);
+        assert.deepStrictEqual(result, [1, 2, 3, 4, 5, 6]);
+    });
+
+    await t.test('array is empty', () => {
+        const result = removeItem([], 2);
+        assert.deepStrictEqual(result, []);
+    });
+
+    // TODO: Error type shold be considered.
+    await t.test('array is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => removeItem(null, 2), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'filter')",
+        });
+    });
+});
+
+test('removeMultipleItems', async (t) => {
+    await t.test('remove items', () => {
+        const result = removeMultipleItems([1, 2, 3, 4, 5, 6], [3, 5]);
+        assert.deepStrictEqual(result, [1, 2, 4, 6]);
+    });
+
+    await t.test("items aren't available", () => {
+        const result = removeMultipleItems([1, 2, 3, 4, 5, 6], [7, 8, 9]);
+        assert.deepStrictEqual(result, [1, 2, 3, 4, 5, 6]);
+    });
+
+    await t.test('items is empty', () => {
+        const result = removeMultipleItems([1, 2, 3, 4, 5, 6], []);
+        assert.deepStrictEqual(result, [1, 2, 3, 4, 5, 6]);
+    });
+
+    // TODO: Error type shold be considered.
+    await t.test("items isn't array (TODO: Error type shold be considered)", () => {
+        assert.throws(() => removeMultipleItems([1, 2, 3, 4, 5, 6], 3), {
+            name: 'TypeError',
+            message: 'itemsToRemove.includes is not a function',
+        });
+    });
+
+    // TODO: Error type shold be considered.
+    await t.test('items is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => removeMultipleItems([1, 2, 3, 4, 5], null), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'includes')",
+        });
+    });
+
+    await t.test('array is empty', () => {
+        const result = removeMultipleItems([], [4, 6]);
+        assert.deepStrictEqual(result, []);
+    });
+
+    // TODO: Error type shold be considered.
+    await t.test('array is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => removeMultipleItems(null, [1, 2, 3]), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'filter')",
+        });
+    });
+});
+
+test('scaleToRange', async (t) => {
+    await t.test('1 to 10 -> 10 to 100', () => {
+        const result = scaleToRange([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 1, 10, 10, 100);
+        assert.deepStrictEqual(result, [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
+    });
+
+    await t.test('1 to 10 -> 10 to 1', () => {
+        const result = scaleToRange([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 1, 10, 10, 1);
+        assert.deepStrictEqual(result, [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    });
+
+    // TODO: TODO: should consider for Floating Point Arithmetic (IEEE 754 https://en.wikipedia.org/wiki/IEEE_754  await t.test(
+    await t.test(
+        '0 to 1 -> 0 to 127 (like MIDI value) (TODO: should consider for Floating Point Arithmetic (IEEE 754 https://en.wikipedia.org/wiki/IEEE_754))',
+        () => {
+            const result = scaleToRange([0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1], 0, 1, 0, 127);
+            assert.deepStrictEqual(
+                result,
+                [
+                    0, 12.700000000000001, 25.400000000000002, 38.1, 50.800000000000004, 63.5, 76.2, 88.89999999999999,
+                    101.60000000000001, 114.3, 127,
+                ]
+            );
+        }
+    );
+});
+test('scaleToSum', async (t) => {
+    await t.test('10 times / sum 6', () => {
+        const result = scaleToSum(10, [1, 2, 3]);
+        assert.deepStrictEqual(result, [10 / 6, 20 / 6, 30 / 6]);
+    });
+
+    await t.test('array is null', () => {
+        assert.throws(() => scaleToSum(10, null), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'reduce')",
+        });
+    });
+});
+
+test('pick', async (t) => {
+    // Override Math.random to return 0.5 for testing.
+    const tmpFn = Math.random;
+    Math.random = () => 0.5;
+    await t.test('pick center value in odd array', () => {
+        const result = pick([1, 2, 3, 4, 5]);
+        assert.equal(result, 3);
+    });
+
+    await t.test('pick upper index in even array', () => {
+        const result = pick([1, 2, 3, 4, 5, 6]);
+        assert.equal(result, 4);
+    });
+
+    await t.test('array is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => pick(null), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'length')",
+        });
+    });
+    // Revert Math.random
+    Math.random = tmpFn;
+});
+
+test('pickN', async (t) => {
+    // Override Math.random to return 0.5 for testing.
+    const tmpFn = Math.random;
+    Math.random = () => 0.5;
+    await t.test('pick center value in odd array', () => {
+        const result = pickN(5, [1, 2, 3, 4, 5]);
+        assert.deepStrictEqual(result, [3, 3, 3, 3, 3]);
+    });
+
+    await t.test('pick upper index in even array', () => {
+        const result = pickN(5, [1, 2, 3, 4, 5, 6]);
+        assert.deepStrictEqual(result, [4, 4, 4, 4, 4]);
+    });
+
+    await t.test('pick 0 length', () => {
+        const result = pickN(0, [1, 2, 3, 4, 5, 6]);
+        assert.deepStrictEqual(result, []);
+    });
+
+    await t.test('pick -1 length', () => {
+        const result = pickN(-1, [1, 2, 3, 4, 5, 6]);
+        assert.deepStrictEqual(result, []);
+    });
+
+    await t.test('array is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => pickN(3, null), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'length')",
+        });
+    });
+
+    // Revert Math.random
+    Math.random = tmpFn;
+});
+
+test('low2HighSort', async (t) => {
+    await t.test('low to high', () => {
+        const result = low2HighSort([8, 2, 4, 9, 6, 7, 1, 3, 5]);
+        assert.deepStrictEqual(result, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    });
+
+    await t.test('array is empty', () => {
+        const result = low2HighSort([]);
+        assert.deepStrictEqual(result, []);
+    });
+
+    await t.test('array is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => low2HighSort(null), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'sort')",
+        });
+    });
+});
+
+test('high2LowSort', async (t) => {
+    await t.test('high to low', () => {
+        const result = high2LowSort([8, 2, 4, 9, 6, 7, 1, 3, 5]);
+        assert.deepStrictEqual(result, [9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    });
+
+    await t.test('array is empty', () => {
+        const result = high2LowSort([]);
+        assert.deepStrictEqual(result, []);
+    });
+
+    // TODO
+    await t.test('array is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => high2LowSort(null), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'sort')",
+        });
+    });
+});
+
+test('takeN', async (t) => {
+    await t.test('n is smaller than length', () => {
+        const result = takeN([1, 2, 3, 4, 5, 6, 7, 8, 9], 3);
+        assert.deepStrictEqual(result, [1, 2, 3]);
+    });
+
+    await t.test('n is bigger than length', () => {
+        const result = takeN([1, 2, 3], 5);
+        assert.deepStrictEqual(result, [1, 2, 3, 1, 2]);
+    });
+
+    await t.test('n is 0', () => {
+        const result = takeN([1, 2, 3], 0);
+        assert.deepStrictEqual(result, []);
+    });
+
+    await t.test('n is -1', () => {
+        const result = takeN([1, 2, 3], -1);
+        assert.deepStrictEqual(result, []);
+    });
+
+    // TODO: Maybe filled by undefined is not unexpected behavior
+    await t.test('array is empty (TODO: Maybe filled by "undefined" is not unexpected behavior)', () => {
+        const result = takeN([], 3);
+        assert.deepStrictEqual(result, [undefined, undefined, undefined]);
+    });
+
+    // TODO
+    await t.test('array is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => takeN(null, 3), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'length')",
+        });
+    });
+});
+
+test('takeTo', async (t) => {
+    await t.test('n is less than sum', () => {
+        const result = takeTo(3, [1, 2, 3]);
+        assert.deepStrictEqual(result, [1, 2]);
+    });
+
+    await t.test('n is bigger than sum', () => {
+        const result = takeTo(15, [1, 2, 3]);
+        assert.deepStrictEqual(result, [1, 2, 3, 1, 2, 3, 1, 2]);
+    });
+
+    await t.test('n is 0', () => {
+        const result = takeTo(0, [1, 2, 3]);
+        assert.deepStrictEqual(result, []);
+    });
+
+    // FIXME: return '[ '-1': NaN ]' when -1 is given.
+    await t.test('n is -1', () => {
+        const result = takeTo(-1, [1, 2, 3]);
+        assert.deepStrictEqual(result, []);
+    });
+
+    // TODO
+    await t.test('array is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => takeTo(3, null), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'length')",
+        });
+    });
+});
+
+test('loopTo', async (t) => {
+    await t.test('loop 2 times', () => {
+        const actual = loopTo(30, [1, 2, 3, 4, 5]);
+        assert.deepStrictEqual(actual, [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]);
+    });
+
+    await t.test('stop at targetLength', () => {
+        const actual = loopTo(3, [1, 2, 3, 4, 5]);
+        assert.deepStrictEqual(actual, [1, 2]);
+    });
+
+    await t.test('targetLength is 0', () => {
+        const actual = loopTo(0, [1, 2, 3, 4, 5]);
+        assert.deepStrictEqual(actual, []);
+    });
+
+    // FIXME: return '[ '-1': NaN ]' when -1 is given.
+    await t.test('targetLength is -1', () => {
+        const actual = loopTo(-1, [1, 2, 3, 4, 5]);
+        assert.deepStrictEqual(actual, []);
+    });
+
+    // FIXME: Maybe it should return empty array.
+    await t.test('array is empty', () => {
+        const actual = loopTo(3, []);
+        assert.deepStrictEqual(actual, []);
+    });
+
+    // TODO
+    await t.test('array is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => loopTo(3, null), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'reduce')",
+        });
+    });
+});
+
+test('zip', async (t) => {
+    await test('same length', () => {
+        const actual = zip([1, 2, 3], [10, 20, 30]);
+        assert.deepStrictEqual(actual, [
+            [1, 10],
+            [2, 20],
+            [3, 30],
+        ]);
+    });
+
+    await test('left is bigger', () => {
+        const actual = zip([1, 2, 3], [10, 20]);
+        assert.deepStrictEqual(actual, [
+            [1, 10],
+            [2, 20],
+        ]);
+    });
+
+    await test('right is bigger', () => {
+        const actual = zip([1, 2], [10, 20, 30]);
+        assert.deepStrictEqual(actual, [
+            [1, 10],
+            [2, 20],
+        ]);
+    });
+});
+
+test('buildZip', async (t) => {
+    await t.test('zip 3 x 3', () => {
+        const actual = buildZip(
+            [
+                [1, 2, 3],
+                [4, 5, 6],
+                [7, 8, 9],
+            ],
+            [
+                [10, 20, 30],
+                [40, 50, 60],
+                [70, 80, 90],
+            ]
+        );
+        assert.deepStrictEqual(actual, [
+            [1, 2, 3, 10, 20, 30],
+            [4, 5, 6, 40, 50, 60],
+            [7, 8, 9, 70, 80, 90],
+        ]);
+    });
+});
+
+test('shuffle', async (t) => {
+    await t.test('include all values', () => {
+        const input = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+        const actual = shuffle(input);
+
+        input.forEach((x) => {
+            assert.equal(actual.includes(x), true);
+        });
+    });
+
+    await t.test('array is empty', () => {
+        const actual = shuffle([]);
+        assert.deepStrictEqual(actual, []);
+    });
+});
+
+test('gatherBySubstring', async (t) => {
+    await t.test('include some values', () => {
+        const actual = gatherBySubstring(['abc', 'def', 'ghi'], ['b', 'i']);
+        assert.deepStrictEqual(actual, ['abc', 'ghi']);
+    });
+
+    await t.test('include nothing', () => {
+        const actual = gatherBySubstring(['abc', 'def', 'ghi'], ['x', 'y', 'z']);
+        assert.deepStrictEqual(actual, []);
+    });
+
+    await t.test('input is empty', () => {
+        const actual = gatherBySubstring([], ['x', 'y', 'z']);
+        assert.deepStrictEqual(actual, []);
+    });
+
+    await t.test('substring is empty', () => {
+        const actual = gatherBySubstring(['abc', 'def', 'ghi'], []);
+        assert.deepStrictEqual(actual, []);
+    });
+
+    // TODO
+    await t.test('input is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => gatherBySubstring(null, ['x', 'y', 'z']), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'filter')",
+        });
+    });
+
+    // TODO
+    await t.test('substring is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => gatherBySubstring(['abc', 'def', 'ghi'], null), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'some')",
+        });
+    });
+});
+
+test('flipBooleans', async (t) => {
+    await t.test('flip', () => {
+        const actual = flipBooleans([true, false, false, true, true]);
+        assert.deepStrictEqual(actual, [false, true, true, false, false]);
+    });
+
+    await t.test('integer', () => {
+        const actual = flipBooleans([0, 1, 2, 3]);
+        assert.deepStrictEqual(actual, [true, false, false, false]);
+    });
+
+    await t.test('array is empty', () => {
+        const actual = flipBooleans([]);
+        assert.deepStrictEqual(actual, []);
+    });
+
+    // TODO
+    await t.test('array is null (TODO: Error type shold be considered)', () => {
+        assert.throws(() => flipBooleans(null), {
+            name: 'TypeError',
+            message: "Cannot read properties of null (reading 'map')",
+        });
+    });
+});


### PR DESCRIPTION
I've written tests for `arrayTransformations`. 
I use `node:test` and `node:assert` that are built in test runner. 
https://nodejs.org/api/test.html
https://nodejs.org/api/assert.html
Maybe recent standard library is Jest. But I think built in test is enough for this kind of small library.

And I've fixed some points for working correctly.
The result of test is as below.
I've not improve some fail tests because I cannot understand these actual behavior.
And I've written notes as `TODO` or `FIXME` in the test for improving something. 
Please confirm them.

I'll make another PR for other tests and some suggestions for improving the style of code or something.

```
$ npm test

> array-toolkit@1.2.2 test
> node --test

▶ adjustArrayLength
  ✔ same length (1.322792ms)
  ✔ smaller length (0.149625ms)
  ✔ larger length (0.066625ms)
  ✔ array is empty (TODO: Error type shold be considered) (0.661292ms)
  ✔ array is null (TODO: Error type shold be considered) (0.129375ms)
▶ adjustArrayLength (3.623625ms)

▶ resizeArray
  ✔ same size (0.141583ms)
  ✔ smaller size (0.373208ms)
  ✔ larger size (0.404583ms)
  ✔ array is empty (TODO: Error type shold be considered) (0.1035ms)
  ✔ array is null (TODO: Error type shold be considered) (0.093709ms)
▶ resizeArray (1.904458ms)

▶ safeSplice
  ✔ splice without replaceWith (0.430625ms)
  ✔ splice with replaceWith (0.265667ms)
  ✔ splice with replaceWith array (0.071875ms)
  ✔ amount is larger than array length (0.225125ms)
  ✔ index is larger than array length (0.6505ms)
  ✔ array is empty without replaceWith (0.968334ms)
  ✔ array is empty with replaceWith (0.436042ms)
  ✔ array is null without replaceWith (TODO: Error type shold be considered) (0.102167ms)
  ✔ array is null with replaceWith (TODO: Error type shold be considered) (0.147334ms)
▶ safeSplice (4.11975ms)

▶ removeItem
  ✔ remove item (0.097959ms)
  ✔ remove multiple items (0.060875ms)
  ✔ remove nothing (0.055208ms)
  ✔ array is empty (0.048458ms)
  ✔ array is null (TODO: Error type shold be considered) (0.075209ms)
▶ removeItem (0.565709ms)

▶ removeMultipleItems
  ✔ remove items (0.082667ms)
  ✔ items aren't available (0.054583ms)
  ✔ items is empty (0.052083ms)
  ✔ items isn't array (TODO: Error type shold be considered) (0.081834ms)
  ✔ items is null (TODO: Error type shold be considered) (0.07225ms)
  ✔ array is empty (0.047375ms)
  ✔ array is null (TODO: Error type shold be considered) (0.070958ms)
▶ removeMultipleItems (0.642916ms)

▶ scaleToRange
  ✔ 1 to 10 -> 10 to 100 (0.094041ms)
  ✔ 1 to 10 -> 10 to 1 (0.06375ms)
  ✔ 0 to 1 -> 0 to 127 (like MIDI value) (TODO: should consider for Floating Point Arithmetic (IEEE 754 https://en.wikipedia.org/wiki/IEEE_754)) (0.083416ms)
▶ scaleToRange (0.340583ms)

▶ scaleToSum
  ✔ 10 times / sum 6 (0.095458ms)
  ✔ array is null (0.073125ms)
▶ scaleToSum (0.242792ms)

▶ pick
  ✔ pick center value in odd array (0.738125ms)
  ✔ pick upper index in even array (0.158167ms)
  ✔ array is null (TODO: Error type shold be considered) (0.15225ms)
▶ pick (1.755292ms)

▶ pickN
  ✔ pick center value in odd array (0.267209ms)
  ✔ pick upper index in even array (0.082708ms)
  ✔ pick 0 length (0.060042ms)
  ✔ pick -1 length (0.369167ms)
  ✔ array is null (TODO: Error type shold be considered) (0.277791ms)
▶ pickN (1.271708ms)

▶ low2HighSort
  ✔ low to high (0.402625ms)
  ✔ array is empty (0.049667ms)
  ✔ array is null (TODO: Error type shold be considered) (0.077125ms)
▶ low2HighSort (0.633ms)

▶ high2LowSort
  ✔ high to low (0.08375ms)
  ✔ array is empty (0.045208ms)
  ✔ array is null (TODO: Error type shold be considered) (0.073625ms)
▶ high2LowSort (0.297333ms)

▶ takeN
  ✔ n is smaller than length (0.093708ms)
  ✔ n is bigger than length (0.055667ms)
  ✔ n is 0 (0.049833ms)
  ✔ n is -1 (0.049166ms)
  ✔ array is empty (TODO: Maybe filled by "undefined" is not unexpected behavior) (0.817417ms)
  ✔ array is null (TODO: Error type shold be considered) (0.092416ms)
▶ takeN (1.334292ms)

▶ takeTo
  ✔ n is less than sum (0.779ms)
  ✔ n is bigger than sum (0.068791ms)
  ✔ n is 0 (0.04425ms)
  ✖ n is -1 (2.1675ms)
    AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
    + actual - expected

    + [
    +   '-1': NaN
    + ]
    - []
        at TestContext.<anonymous> (file:///Users/n/src/github.com/reprimande/array-toolkit/test/arrayTransformations.mjs:421:16)
        at Test.runInAsyncScope (node:async_hooks:206:9)
        at Test.run (node:internal/test_runner/test:580:25)
        at Test.start (node:internal/test_runner/test:493:17)
        at TestContext.test (node:internal/test_runner/test:129:20)
        at TestContext.<anonymous> (file:///Users/n/src/github.com/reprimande/array-toolkit/test/arrayTransformations.mjs:419:13)
        at async Test.run (node:internal/test_runner/test:581:9)
        at async Test.processPendingSubtests (node:internal/test_runner/test:325:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: [ '-1': NaN ],
      expected: [],
      operator: 'deepStrictEqual'
    }

  ✔ array is null (TODO: Error type shold be considered) (0.141208ms)
▶ takeTo (3.494417ms)

▶ loopTo
  ✔ loop 2 times (0.189375ms)
  ✔ stop at targetLength (0.332084ms)
  ✔ targetLength is 0 (0.049125ms)
  ✖ targetLength is -1 (0.542667ms)
    AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
    + actual - expected

    + [
    +   '-1': NaN
    + ]
    - []
        at TestContext.<anonymous> (file:///Users/n/src/github.com/reprimande/array-toolkit/test/arrayTransformations.mjs:452:16)
        at Test.runInAsyncScope (node:async_hooks:206:9)
        at Test.run (node:internal/test_runner/test:580:25)
        at Test.start (node:internal/test_runner/test:493:17)
        at TestContext.test (node:internal/test_runner/test:129:20)
        at TestContext.<anonymous> (file:///Users/n/src/github.com/reprimande/array-toolkit/test/arrayTransformations.mjs:450:13)
        at async Test.run (node:internal/test_runner/test:581:9)
        at async Test.processPendingSubtests (node:internal/test_runner/test:325:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: [ '-1': NaN ],
      expected: [],
      operator: 'deepStrictEqual'
    }

  ✖ array is empty (0.072125ms)
    RangeError [Error]: Invalid array length
        at Function.from (<anonymous>)
        at buildArray (/Users/n/src/github.com/reprimande/array-toolkit/dataToArray.js:10:18)
        at loopTo (/Users/n/src/github.com/reprimande/array-toolkit/arrayTransformations.js:110:27)
        at TestContext.<anonymous> (file:///Users/n/src/github.com/reprimande/array-toolkit/test/arrayTransformations.mjs:457:24)
        at Test.runInAsyncScope (node:async_hooks:206:9)
        at Test.run (node:internal/test_runner/test:580:25)
        at Test.start (node:internal/test_runner/test:493:17)
        at TestContext.test (node:internal/test_runner/test:129:20)
        at TestContext.<anonymous> (file:///Users/n/src/github.com/reprimande/array-toolkit/test/arrayTransformations.mjs:456:13)
        at async Test.run (node:internal/test_runner/test:581:9)

  ✔ array is null (TODO: Error type shold be considered) (0.074667ms)
▶ loopTo (1.4685ms)

▶ zip
  ✔ same length (0.161916ms)
  ✔ left is bigger (0.054333ms)
  ✔ right is bigger (0.047125ms)
▶ zip (0.581166ms)

▶ buildZip
  ✔ zip 3 x 3 (0.297459ms)
▶ buildZip (0.352625ms)

▶ shuffle
  ✔ include all values (0.127584ms)
  ✔ array is empty (0.363084ms)
▶ shuffle (0.69325ms)

▶ gatherBySubstring
  ✔ include some values (0.092541ms)
  ✔ include nothing (0.04275ms)
  ✔ input is empty (0.03875ms)
  ✔ substring is empty (0.037042ms)
  ✔ input is null (TODO: Error type shold be considered) (0.0715ms)
  ✔ substring is null (TODO: Error type shold be considered) (0.073042ms)
▶ gatherBySubstring (0.495208ms)

▶ flipBooleans
  ✔ flip (0.074375ms)
  ✔ integer (0.041125ms)
  ✔ array is empty (0.036125ms)
  ✔ array is null (TODO: Error type shold be considered) (0.060792ms)
▶ flipBooleans (0.314917ms)

ℹ tests 102
ℹ suites 0
ℹ pass 97
ℹ fail 5
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 266.192875

✖ failing tests:

✖ n is -1 (2.1675ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
  + actual - expected

  + [
  +   '-1': NaN
  + ]
  - []
      at TestContext.<anonymous> (file:///Users/n/src/github.com/reprimande/array-toolkit/test/arrayTransformations.mjs:421:16)
      at Test.runInAsyncScope (node:async_hooks:206:9)
      at Test.run (node:internal/test_runner/test:580:25)
      at Test.start (node:internal/test_runner/test:493:17)
      at TestContext.test (node:internal/test_runner/test:129:20)
      at TestContext.<anonymous> (file:///Users/n/src/github.com/reprimande/array-toolkit/test/arrayTransformations.mjs:419:13)
      at async Test.run (node:internal/test_runner/test:581:9)
      at async Test.processPendingSubtests (node:internal/test_runner/test:325:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: [ '-1': NaN ],
    expected: [],
    operator: 'deepStrictEqual'
  }

✖ targetLength is -1 (0.542667ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
  + actual - expected

  + [
  +   '-1': NaN
  + ]
  - []
      at TestContext.<anonymous> (file:///Users/n/src/github.com/reprimande/array-toolkit/test/arrayTransformations.mjs:452:16)
      at Test.runInAsyncScope (node:async_hooks:206:9)
      at Test.run (node:internal/test_runner/test:580:25)
      at Test.start (node:internal/test_runner/test:493:17)
      at TestContext.test (node:internal/test_runner/test:129:20)
      at TestContext.<anonymous> (file:///Users/n/src/github.com/reprimande/array-toolkit/test/arrayTransformations.mjs:450:13)
      at async Test.run (node:internal/test_runner/test:581:9)
      at async Test.processPendingSubtests (node:internal/test_runner/test:325:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: [ '-1': NaN ],
    expected: [],
    operator: 'deepStrictEqual'
  }

✖ array is empty (0.072125ms)
  RangeError [Error]: Invalid array length
      at Function.from (<anonymous>)
      at buildArray (/Users/n/src/github.com/reprimande/array-toolkit/dataToArray.js:10:18)
      at loopTo (/Users/n/src/github.com/reprimande/array-toolkit/arrayTransformations.js:110:27)
      at TestContext.<anonymous> (file:///Users/n/src/github.com/reprimande/array-toolkit/test/arrayTransformations.mjs:457:24)
      at Test.runInAsyncScope (node:async_hooks:206:9)
      at Test.run (node:internal/test_runner/test:580:25)
      at Test.start (node:internal/test_runner/test:493:17)
      at TestContext.test (node:internal/test_runner/test:129:20)
      at TestContext.<anonymous> (file:///Users/n/src/github.com/reprimande/array-toolkit/test/arrayTransformations.mjs:456:13)
      at async Test.run (node:internal/test_runner/test:581:9)
```